### PR TITLE
fix: Support for recent versions/url introduced

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -86,6 +86,8 @@ get_download_url () {
     echo "https://github.com/docker-slim/docker-slim/releases/download/${zip_archive}"
   elif ${_exists} "https://github.com/docker-slim/docker-slim/releases/download/${targz_archive}"; then
     echo "https://github.com/docker-slim/docker-slim/releases/download/${targz_archive}"
+  elif ${_exists} "https://downloads.dockerslim.com/releases/${targz_archive}"; then
+    echo "https://downloads.dockerslim.com/releases/${targz_archive}"
   fi
 }
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -5,7 +5,7 @@ set \
   -o pipefail \
   -o errexit
 
-readonly VER_REGEX='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)'
+readonly VER_REGEX='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))?'
 
 get_git_tags () {
   local -r repo_url="$1"
@@ -13,10 +13,12 @@ get_git_tags () {
   local tag
   for tag in $(git ls-remote --tags "${repo_url}"); do
     if [[ ${tag} =~ refs/tags/${VER_REGEX}$ ]]; then
-        version="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+        version="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}${BASH_REMATCH[3]}"
         if curl --output /dev/null --silent --fail --head "$(get_download_url "${version}")"; then
           echo "${version}"
-        elif curl --output /dev/null --silent --fail --head "$(get_download_url "${version}" ".tar.gz")"; then
+	elif curl --output /dev/null --silent --fail --head "$(get_download_url "${version}" ".tar.gz")"; then
+          echo "${version}"
+	elif curl --output /dev/null --silent --fail --head "$(get_download_url "${version}" ".tar.gz" "https://downloads.dockerslim.com/releases")"; then
           echo "${version}"
         fi
     fi
@@ -47,9 +49,10 @@ get_filename () {
 get_download_url () {
   local -r version="$1"
   local -r ext="${2:-.zip}"
+  local -r url_base="${3:-https://github.com/docker-slim/docker-slim/releases/download}"
 
   local -r filename="$(get_filename "${version}" "${ext}")"
-  echo "https://github.com/docker-slim/docker-slim/releases/download/${filename}"
+  echo "${url_base}/${filename}"
 }
 
 list_all () {


### PR DESCRIPTION
This should fix support for recent versions of `docker-slim`.